### PR TITLE
Physical Quantities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
 name = "GeodesicBase"
 uuid = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"

--- a/src/GeodesicBase.jl
+++ b/src/GeodesicBase.jl
@@ -5,11 +5,10 @@ include("metric-params.jl")
 # contains the full metric components (this type needed for DiffGeoSymbolics)
 abstract type AbstractMetric{T} <: AbstractMatrix{T} end
 
-abstract type AbstractGeodesicParams{M,T} end 
 
 metric_params(m::AbstractMetric{T}) where {T} = error("Not implemented for metric $(typeof(m))")
 
-export AbstractMetricParams, AbstractGeodesicParams, metric_params
+export AbstractMetricParams, metric_params
 
 
 end # module

--- a/src/GeodesicBase.jl
+++ b/src/GeodesicBase.jl
@@ -3,7 +3,7 @@ module GeodesicBase
 include("metric-params.jl")
 include("physical-quantities.jl")
 
-export AbstractMetricParams, metric_params
+export AbstractMetricParams, metric_params, metric
 
 
 end # module

--- a/src/GeodesicBase.jl
+++ b/src/GeodesicBase.jl
@@ -1,12 +1,7 @@
 module GeodesicBase
 
 include("metric-params.jl")
-
-# contains the full metric components (this type needed for DiffGeoSymbolics)
-abstract type AbstractMetric{T} <: AbstractMatrix{T} end
-
-
-metric_params(m::AbstractMetric{T}) where {T} = error("Not implemented for metric $(typeof(m))")
+include("physical-quantities.jl")
 
 export AbstractMetricParams, metric_params
 

--- a/src/metric-params.jl
+++ b/src/metric-params.jl
@@ -64,11 +64,13 @@ and some point `u`.
 """
 metric(m::AbstractMetricParams{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
 
-"""
-    metric(m::AbstractMetric{T}, u) 
-
-Evaluate the metric at a point `u`.
-"""
-metric(m::AbstractMetric{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
+# do we actually want to support this?
+# since if it's a symbolic matrix, you can subs other ways better?
+#"""
+#    metric(m::AbstractMetric{T}, u) 
+#
+#Evaluate the metric at a point `u`.
+#"""
+#metric(m::AbstractMetric{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
 
 export AbstractMetricParams, geodesic_eq, geodesic_eq!, constrain, on_chart, inner_radius, metric_type

--- a/src/metric-params.jl
+++ b/src/metric-params.jl
@@ -6,6 +6,11 @@ Abstract type used to dispatch different geodesic problems.
 abstract type AbstractMetricParams{T} end
 
 
+# contains the full metric components (this type needed for DiffGeoSymbolics)
+abstract type AbstractMetric{T} <: AbstractMatrix{T} end
+
+metric_params(m::AbstractMetric{T}) where {T} = error("Not implemented for metric $(typeof(m))")
+
 """
     geodesic_eq(m::AbstractMetricParams{T}, u, v)
     geodesic_eq!(m::AbstractMetricParams{T}, u, v)
@@ -24,7 +29,7 @@ geodesic with mass `μ`.
 constrain(m::AbstractMetricParams{T}, u, v; μ::T=0.0) where {T} = error("Not implemented for metric parameters $(typeof(m))")
 
 """
-    on_chart(m::AbstractMetricParams{T}, u::AbstractVector)
+    on_chart(m::AbstractMetricParams{T}, u)
 
 Check if point `u` is a valid point for the metric described by `m`.
 
@@ -50,5 +55,20 @@ Return the [`AbstractMetric`](@ref) type associated with the metric parameters `
 """
 metric_type(m::AbstractMetricParams{T}) where {T} = error("Not implemented for metric parameters $(typeof(m))")
 
+
+"""
+    metric(m::AbstractMetricParams{T}, u) 
+
+Numerically evaluate the corresponding metric for [`AbstractMetricParams`](@ref), given parameter values `m`
+and some point `u`.
+"""
+metric(m::AbstractMetricParams{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
+
+"""
+    metric(m::AbstractMetric{T}, u) 
+
+Evaluate the metric at a point `u`.
+"""
+metric(m::AbstractMetric{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
 
 export AbstractMetricParams, geodesic_eq, geodesic_eq!, constrain, on_chart, inner_radius, metric_type

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -1,0 +1,19 @@
+
+# both energy and angular momentum 
+# assume time only coupled to radial coordinate
+# need to think of a nice way to keep this efficient
+# whilst allowing metrics with other couplings
+
+function E(m::AbstractMatrix{T}, v) where {T}
+    @inbounds metric[1, 1] * v[1] + metric[1, 4] * v[4]
+end
+
+
+"""
+    Lz(m::AbstractMetricParams{T}, v)
+
+Compute the angular momentum for a 
+"""
+function Lz(m::AbstractMatrix{T}, v) where {T}
+    @inbounds -metric[4,4] * v[4] - metric[1,4] * v[1]
+end

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -9,7 +9,7 @@
 
 Compute the energy for a numerically evaluated metric, and some velocity four vector `v`.
 """
-function E(m::AbstractMatrix{T}, v) where {T}
+function E(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds metric[1, 1] * v[1] + metric[1, 4] * v[4])
 end
 
@@ -19,6 +19,6 @@ end
 
 Compute the angular momentum for a numerically evaluated metric, and some velocity four vector `v`.
 """
-function Lz(m::AbstractMatrix{T}, v) where {T}
+function Lz(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds -metric[4,4] * v[4] - metric[1,4] * v[1])
 end

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -4,16 +4,21 @@
 # need to think of a nice way to keep this efficient
 # whilst allowing metrics with other couplings
 
+"""
+    E(m::AbstractMatrix{T}, v) 
+
+Compute the energy for a numerically evaluated metric, and some velocity four vector `v`.
+"""
 function E(m::AbstractMatrix{T}, v) where {T}
-    @inbounds metric[1, 1] * v[1] + metric[1, 4] * v[4]
+    T(@inbounds metric[1, 1] * v[1] + metric[1, 4] * v[4])
 end
 
 
 """
-    Lz(m::AbstractMetricParams{T}, v)
+    Lz(m::AbstractMatrix{T}, v)
 
-Compute the angular momentum for a 
+Compute the angular momentum for a numerically evaluated metric, and some velocity four vector `v`.
 """
 function Lz(m::AbstractMatrix{T}, v) where {T}
-    @inbounds -metric[4,4] * v[4] - metric[1,4] * v[1]
+    T(@inbounds -metric[4,4] * v[4] - metric[1,4] * v[1])
 end


### PR DESCRIPTION
Added some base methods for computing "generic" physical quantities, i.e. quantities that are conceptually generic. The precise definition of this is to be determined, but loosely they are functions that might be of interest to GeodesicTracer.jl users, as well as AccretionFormulae.jl.

At the moment, this includes energy `E` and angular momentum `Lz`.