### PR TITLE
Sign Convention

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
 name = "GeodesicBase"
 uuid = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -6,11 +6,17 @@
 
 """
     E(m::AbstractMatrix{T}, v) 
+    
+Compute the energy for a numerically evaluated metric, and some velocity four vector `v`,
+```math
+E = - p_t = - g_{t\\nu} p^\\nu.
+```
 
-Compute the energy for a numerically evaluated metric, and some velocity four vector `v`.
+For null geodesics, the velocity is the momentum ``v^\\nu = p^\\nu``. For massive geodesics,
+the mass ``\\mu`` needs to be known to compute ``\\mu v^\\nu = p^\\nu``.
 """
 function E(metric::AbstractMatrix{T}, v) where {T}
-    T(@inbounds metric[1, 1] * v[1] + metric[1, 4] * v[4])
+    T(@inbounds -(metric[1, 1] * v[1] + metric[1, 4] * v[4]))
 end
 
 
@@ -18,7 +24,10 @@ end
     Lz(m::AbstractMatrix{T}, v)
 
 Compute the angular momentum for a numerically evaluated metric, and some velocity four vector `v`.
+```math
+L_z = p_\\phi = - g_{\\phi\\nu} p^\\nu.
+```
 """
 function Lz(metric::AbstractMatrix{T}, v) where {T}
-    T(@inbounds -metric[4,4] * v[4] - metric[1,4] * v[1])
+    T(@inbounds metric[4,4] * v[4] + metric[1,4] * v[1])
 end


### PR DESCRIPTION
There needs to be some standardisation of sign convention in the ecosystem before we start adding too many physical functions. The reason for this is; the integrator integrates geodesics "forward", but we then interpret the results, at least for observer to disc integrations, as "backwards".

Calculations which involve the momentum therefore need to flip the sign of the velocity vectors depending on the which regime we are looking at.

My proposal is to let the full ecosystem (starting with this PR) use the convention that all integrations are "forward" with respect to calculating physical quantities, and let users integrating problems backwards tackle the convention themselves; e.g.:
- AccretionFormulae.jl functions, which are designed to be used with GeodesicRendering.jl, should adopt the **backward** convention
- GeodesicTracer.jl, CarterBoyerLindquist.jl, ComputedGeodesicsEquations.jl can all be used as just stand-alone geodesic calculators, and therefore should adopt the **forward** convention.