### PR TITLE
Geodesic Type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeodesicBase"
 uuid = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,8 @@
 name = "GeodesicBase"
 uuid = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
+
+[deps]
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"

--- a/src/GeodesicBase.jl
+++ b/src/GeodesicBase.jl
@@ -1,7 +1,11 @@
 module GeodesicBase
 
+import Parameters: @with_kw
+import SciMLBase
+
 include("metric-params.jl")
 include("physical-quantities.jl")
+include("geodesic-solutions.jl")
 
 export AbstractMetricParams, metric_params, metric
 

--- a/src/geodesic-solutions.jl
+++ b/src/geodesic-solutions.jl
@@ -1,0 +1,36 @@
+abstract type AbstractGeodesic{T} end
+
+@with_kw struct GeodesicPoint{T,P} <: AbstractGeodesic{T}
+    u::AbstractVector{T}
+    v::AbstractVector{T}
+    t::T
+    p::P
+end
+
+# TODO: GeodesicPath structure for the full geodesic path
+# do we want to support this?
+
+function unpack_solution(sol::SciMLBase.AbstractODESolution{T,N,S}) where {T,N,S}
+    u = sol.u
+    p = sol.prob.p
+    t = sol.t
+    (u, t, p)
+end
+
+function unpack_solution(simsol::SciMLBase.AbstractEnsembleSolution{T,N,V}) where {T,N,V}
+    map(unpack_solution, simsol)
+end
+
+function get_endpoint(m::AbstractMetricParams{T}, sol::SciMLBase.AbstractODESolution{T,N,S}) where {T,N,S}
+    us, ts, p = unpack_solution(sol)
+    u = us[end].x[2]
+    v = us[end].x[1]
+    t = ts[end]
+    GeodesicPoint(u, v, t, p)
+end
+
+function get_endpoint(m::AbstractMetricParams{T}, simsol::SciMLBase.AbstractEnsembleSolution{T,N,S}) where {T,N,S}
+    map(sol -> get_endpoint(m, sol), simsol)
+end
+
+export get_endpoint, GeodesicPoint

--- a/src/geodesic-solutions.jl
+++ b/src/geodesic-solutions.jl
@@ -1,10 +1,18 @@
-abstract type AbstractGeodesic{T} end
+abstract type AbstractGeodesicPoint{T} end
 
-@with_kw struct GeodesicPoint{T,P} <: AbstractGeodesic{T}
+@with_kw struct GeodesicPoint{T} <: AbstractGeodesicPoint{T}
+    retcode::Symbol
+    t::T
     u::AbstractVector{T}
     v::AbstractVector{T}
-    t::T
-    p::P
+    # we don't store the problem parameters
+    # and can create a specialistion for the carter method
+    # then provide dispatched accessor methods
+    # p::P
+end
+
+function geodesic_point_type(m::AbstractMetricParams{T}) where {T}
+    GeodesicPoint{T}
 end
 
 # TODO: GeodesicPath structure for the full geodesic path
@@ -21,15 +29,21 @@ function unpack_solution(simsol::SciMLBase.AbstractEnsembleSolution{T,N,V}) wher
     map(unpack_solution, simsol)
 end
 
-function get_endpoint(m::AbstractMetricParams{T}, sol::SciMLBase.AbstractODESolution{T,N,S}) where {T,N,S}
-    us, ts, p = unpack_solution(sol)
+function get_endpoint(
+    m::AbstractMetricParams{T},
+    sol::SciMLBase.AbstractODESolution{T,N,S},
+) where {T,N,S}
+    us, ts, _ = unpack_solution(sol)
     u = us[end].x[2]
     v = us[end].x[1]
     t = ts[end]
-    GeodesicPoint(u, v, t, p)
+    GeodesicPoint(sol.retcode, t, u, v)
 end
 
-function get_endpoint(m::AbstractMetricParams{T}, simsol::SciMLBase.AbstractEnsembleSolution{T,N,S}) where {T,N,S}
+function get_endpoint(
+    m::AbstractMetricParams{T},
+    simsol::SciMLBase.AbstractEnsembleSolution{T,N,S},
+) where {T,N,S}
     map(sol -> get_endpoint(m, sol), simsol)
 end
 

--- a/src/metric-params.jl
+++ b/src/metric-params.jl
@@ -9,7 +9,8 @@ abstract type AbstractMetricParams{T} end
 # contains the full metric components (this type needed for DiffGeoSymbolics)
 abstract type AbstractMetric{T} <: AbstractMatrix{T} end
 
-metric_params(m::AbstractMetric{T}) where {T} = error("Not implemented for metric $(typeof(m))")
+metric_params(m::AbstractMetric{T}) where {T} =
+    error("Not implemented for metric $(typeof(m))")
 
 """
     geodesic_eq(m::AbstractMetricParams{T}, u, v)
@@ -17,8 +18,10 @@ metric_params(m::AbstractMetric{T}) where {T} = error("Not implemented for metri
 
 Calculate the acceleration components of the geodesic equation given a position `u`, a velocity `v`, and a metric `m`.
 """
-geodesic_eq(m::AbstractMetricParams{T}, u, v) where {T} = error("Not implemented for metric parameters $(typeof(m))")
-geodesic_eq!(m::AbstractMetricParams{T}, u, v) where {T} = error("Not implemented for metric parameters $(typeof(m))")
+geodesic_eq(m::AbstractMetricParams{T}, u, v) where {T} =
+    error("Not implemented for metric parameters $(typeof(m))")
+geodesic_eq!(m::AbstractMetricParams{T}, u, v) where {T} =
+    error("Not implemented for metric parameters $(typeof(m))")
 
 """
     constrain(m::AbstractMetricParams{T}, u, v; μ::T=0.0f0)
@@ -26,7 +29,8 @@ geodesic_eq!(m::AbstractMetricParams{T}, u, v) where {T} = error("Not implemente
 Give time component which would constrain a velocity vector `v` at position `x` to be a
 geodesic with mass `μ`.
 """
-constrain(m::AbstractMetricParams{T}, u, v; μ::T=0.0) where {T} = error("Not implemented for metric parameters $(typeof(m))")
+constrain(m::AbstractMetricParams{T}, u, v; μ::T = 0.0) where {T} =
+    error("Not implemented for metric parameters $(typeof(m))")
 
 """
     on_chart(m::AbstractMetricParams{T}, u)
@@ -53,7 +57,8 @@ inner_radius(m::AbstractMetricParams{T}) where {T} = convert(T, 0.0)
 
 Return the [`AbstractMetric`](@ref) type associated with the metric parameters `m`.
 """
-metric_type(m::AbstractMetricParams{T}) where {T} = error("Not implemented for metric parameters $(typeof(m))")
+metric_type(m::AbstractMetricParams{T}) where {T} =
+    error("Not implemented for metric parameters $(typeof(m))")
 
 
 """
@@ -62,7 +67,8 @@ metric_type(m::AbstractMetricParams{T}) where {T} = error("Not implemented for m
 Numerically evaluate the corresponding metric for [`AbstractMetricParams`](@ref), given parameter values `m`
 and some point `u`.
 """
-metric(m::AbstractMetricParams{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
+metric(m::AbstractMetricParams{T}, u) where {T} =
+    error("Not implemented for metric $(typeof(m))")
 
 # do we actually want to support this?
 # since if it's a symbolic matrix, you can subs other ways better?
@@ -73,4 +79,5 @@ metric(m::AbstractMetricParams{T}, u) where {T} = error("Not implemented for met
 #"""
 #metric(m::AbstractMetric{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
 
-export AbstractMetricParams, geodesic_eq, geodesic_eq!, constrain, on_chart, inner_radius, metric_type
+export AbstractMetricParams,
+    geodesic_eq, geodesic_eq!, constrain, on_chart, inner_radius, metric_type

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -29,5 +29,5 @@ L_z = p_\\phi = - g_{\\phi\\nu} p^\\nu.
 ```
 """
 function Lz(metric::AbstractMatrix{T}, v) where {T}
-    T(@inbounds metric[4,4] * v[4] + metric[1,4] * v[1])
+    T(@inbounds metric[4, 4] * v[4] + metric[1, 4] * v[1])
 end


### PR DESCRIPTION
Added the `AbstractGeodesic` abstract type, and `GeodesicPoint` concrete type, along with solution unpacking methods.

Related to fixing 

- https://github.com/astro-group-bristol/GeodesicRendering.jl/issues/9

Example:
```julia
using GeodesicBase
using GeodesicTracer
using ComputedGeodesicEquations
using StaticArrays

m = BoyerLindquist(M=1.0, a=1.0)

u = @SVector [0.0, 1000.0, deg2rad(85), 0.0]

alpha = collect(0.1:0.6:20.0)
beta = [0.0 for _ in alpha]

vs = map_impact_parameters(m, u, alpha, beta)
us = [u for _ in vs]

simsols = @time tracegeodesics(
    m,
    us, vs,
    (0.0, 2000.0),
    abstol=1e-8, reltol=1e-8
)

GeodesicBase.get_endpoint(m, simsols)
```