### PR TITLE
E & Lz Overloads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeodesicBase"
 uuid = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -18,6 +18,7 @@ the mass ``\\mu`` needs to be known to compute ``\\mu v^\\nu = p^\\nu``.
 function E(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds -(metric[1, 1] * v[1] + metric[1, 4] * v[4]))
 end
+E(m::AbstractMetricParams{T}, u, v) where {T} = E(metric(m, u), v)
 
 
 """
@@ -31,3 +32,4 @@ L_z = p_\\phi = - g_{\\phi\\nu} p^\\nu.
 function Lz(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds metric[4, 4] * v[4] + metric[1, 4] * v[1])
 end
+Lz(m::AbstractMetricParams{T}, u, v) where {T} = Lz(metric(m, u), v)

--- a/src/physical-quantities.jl
+++ b/src/physical-quantities.jl
@@ -6,6 +6,7 @@
 
 """
     E(m::AbstractMatrix{T}, v) 
+    E(m::AbstractMetricParams{T}, u, v)
     
 Compute the energy for a numerically evaluated metric, and some velocity four vector `v`,
 ```math
@@ -23,6 +24,7 @@ E(m::AbstractMetricParams{T}, u, v) where {T} = E(metric(m, u), v)
 
 """
     Lz(m::AbstractMatrix{T}, v)
+    Lz(m::AbstractMetricParams{T}, u, v) 
 
 Compute the angular momentum for a numerically evaluated metric, and some velocity four vector `v`.
 ```math


### PR DESCRIPTION
Added methods so that `E` and `Lz` can be called with `AbstractMetricParams` types.